### PR TITLE
fix: add ignore_changes lifecycle to operation-id annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix constant drift adding `ignore_changes` lifecycle rule to `google_cloud_service.metadata.annotations`
+
 ## [0.2.0]
 
 ### Changed

--- a/main.tf
+++ b/main.tf
@@ -114,6 +114,12 @@ resource "google_cloud_run_service" "service" {
     update = try(var.module_timeouts.google_cloud_run_service.update, "15m")
     delete = try(var.module_timeouts.google_cloud_run_service.delete, "4m")
   }
+
+  lifecycle {
+    ignore_changes = [
+      metadata[0].annotations["run.googleapis.com/operation-id"]
+    ]
+  }
 }
 
 resource "google_cloud_run_domain_mapping" "domain_mapping" {


### PR DESCRIPTION
change ignored on annotation "run.googleapis.com/operation-id" because it creates a constant drift on plan time
https://app.shortcut.com/mineiros/story/7375/cloud-run-metadata-field-creates-constant-drift